### PR TITLE
Fix circular self-dependency in package.json

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-import { generate } from '../dist/cli.js';
+import { generate } from '../dist/src/cli.js';
 generate();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "chalk": "^5.4.1",
         "langium": "^3.3.1",
-        "langium-visitor": "file:",
         "minimist": "^1.2.8",
         "nunjucks": "^3.2.4"
       },
@@ -2329,10 +2328,6 @@
         "langium": "~3.3.0",
         "railroad-diagrams": "~1.0.0"
       }
-    },
-    "node_modules/langium-visitor": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "langium": "^3.3.1",
-    "langium-visitor": "file:",
     "minimist": "^1.2.8",
     "nunjucks": "^3.2.4"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { AstTypes, collectAst, InterfaceType, isArrayType, isInterfaceType, isPr
 import chalk from "chalk";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const templatesDir = path.resolve(__dirname, "..", "templates");
+const templatesDir = path.resolve(__dirname, "..", "..", "templates");
 
 /**
  * Generate the visitor files from a Langium grammar


### PR DESCRIPTION
Problem: The package.json includes itself as a dependency using "langium-visitor": "file:". This causes package managers (like Yarn) to resolve the dependency to a local absolute path in the cache. This breaks the installation for anyone else working on a different machine.

Solution: Remove the "langium-visitor": "file:" line from the dependencies to ensure correct cross-platform installation. Also change the relative path to match the dist folder.